### PR TITLE
Add expand/collapse for over 5 users and tags

### DIFF
--- a/web-vite/src/app/stats.tsx
+++ b/web-vite/src/app/stats.tsx
@@ -1,4 +1,9 @@
+import { useState } from 'preact/hooks';
+
 export function Stats({ stats, loading }) {
+  const [expandedUsers, setExpandedUsers] = useState(false);
+  const [expandedTags, setExpandedTags] = useState(false);
+
   if (loading || !stats) {
     return (
       <article class="stats">
@@ -52,6 +57,25 @@ export function Stats({ stats, loading }) {
           </table>
         </section>
         <section>
+          <h3>User Stats</h3>
+          <table class="loading__wrapper">
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Features</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from(Array(5).keys()).map((x) => {
+                return (<tr key={x}>
+                  <td class="loading" />
+                  <td class="loading" />
+                </tr>)
+              })}
+            </tbody>
+          </table>
+        </section>
+        <section>
           <h3>Tag Stats</h3>
           <table class="loading__wrapper">
             <thead>
@@ -61,7 +85,7 @@ export function Stats({ stats, loading }) {
               </tr>
             </thead>
             <tbody>
-              {Array.from(Array(12).keys()).map((x) => {
+              {Array.from(Array(4).keys()).map((x) => {
                 return (<tr key={x}>
                   <td class="loading" />
                   <td class="loading" />
@@ -158,25 +182,6 @@ export function Stats({ stats, loading }) {
         </table>
       </section>
       <section>
-        <h3>Tag Stats</h3>
-        <table>
-          <thead>
-            <tr>
-              <th>Tag</th>
-              <th>Count</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sortedTags.map((k) => (
-              <tr>
-                <td>{k[0]}</td>
-                <td>{k[1]}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </section>
-      <section>
         <h3>User Stats</h3>
         <table>
           <thead>
@@ -186,12 +191,45 @@ export function Stats({ stats, loading }) {
             </tr>
           </thead>
           <tbody>
-            {sortedUsers.map((k) => (
+            {sortedUsers.slice(0,5).map((k) => (
               <tr>
                 <td>{k[0]}</td>
                 <td>{k[1]}</td>
               </tr>
             ))}
+            {expandedUsers && sortedUsers.slice(5).map((k) => (
+              <tr>
+                <td>{k[0]}</td>
+                <td>{k[1]}</td>
+              </tr>
+            ))}
+            {sortedUsers.length > 5 && <tr onClick={() => setExpandedUsers(!expandedUsers)}><td class="tr--button" colSpan={2}>{!expandedUsers ? 'See more +' : 'See less -'}</td></tr>}
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h3>Tag Stats</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Tag</th>
+              <th>Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedTags.slice(0,5).map((k) => (
+              <tr>
+                <td>{k[0]}</td>
+                <td>{k[1]}</td>
+              </tr>
+            ))}
+            {expandedTags && sortedTags.slice(5).map((k) => (
+              <tr>
+                <td>{k[0]}</td>
+                <td>{k[1]}</td>
+              </tr>
+            ))}
+            {sortedTags.length > 5 && <tr onClick={() => setExpandedTags(!expandedTags)}><td class="tr--button" colSpan={2}>{!expandedTags ? 'See more +' : 'See less -'}</td></tr>}
           </tbody>
         </table>
       </section>

--- a/web-vite/src/index.css
+++ b/web-vite/src/index.css
@@ -112,6 +112,7 @@ body {
   position: relative;
   top: -1rem;
   height: calc(100% + 1rem);
+  z-index: 100;
 }
 .panel.open {
   top: 12vh;
@@ -255,6 +256,15 @@ li.bar-chart__bar {
 }
 .loading:first-child:after {
   left:0;
+}
+.tr--button {
+  text-align: center;
+  font-weight: bold;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+}
+.tr--button:hover {
+  border-color: rgba(255, 255, 255, 0.5);
 }
 @keyframes skeleton-loading {
   to {


### PR DESCRIPTION
When there are more than 5 users and/or more than 5 tags, collapse these and displays "Show more"

<img width="383" alt="image" src="https://github.com/developmentseed/osm-tardis/assets/12634024/f0ca9f54-649c-4a9c-bbd3-a1f9771817e4">
